### PR TITLE
Update testCompile to rely on assertj-android 1.0.1

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.0.7-beta"
-    testCompile "com.squareup.assertj:assertj-android:1.0.1-SNAPSHOT"
+    testCompile "com.squareup.assertj:assertj-android:1.0.1"
     testCompile "org.robolectric:robolectric:3.0-rc2"
 }
 


### PR DESCRIPTION
Resolves TonicArtos/SuperSLiM#123 by relying on a non-SNAPSHOT assertj-android.