### PR TITLE
Allow subclasses of SectionAdapter.Section access to NO_POSITION.

### DIFF
--- a/library/src/main/java/com/tonicartos/superslim/SectionAdapter.java
+++ b/library/src/main/java/com/tonicartos/superslim/SectionAdapter.java
@@ -9,7 +9,7 @@ public interface SectionAdapter<T extends SectionAdapter.Section> {
 
     public abstract class Section<T extends Section> {
 
-        static final int NO_POSITION = -1;
+        public static final int NO_POSITION = -1;
 
         public int end = NO_POSITION;
 


### PR DESCRIPTION
My use of the SectionAdapter.Section doesn't actually add any functionality... is it possible to make it a non-abstract class?