### PR TITLE
Check for null adapater in onAdapterChanged.

### DIFF
--- a/library/src/main/java/com/tonicartos/superslim/LayoutManager.java
+++ b/library/src/main/java/com/tonicartos/superslim/LayoutManager.java
@@ -303,13 +303,15 @@ public class LayoutManager extends RecyclerView.LayoutManager {
     public void onAdapterChanged(RecyclerView.Adapter oldAdapter, RecyclerView.Adapter newAdapter) {
         removeAllViews();
 
-        if (!(newAdapter instanceof SectionAdapter)) {
-            throw new SectionAdapterNotImplementedRuntimeException();
+        if (newAdapter != null) {
+            if (!(newAdapter instanceof SectionAdapter)) {
+                throw new SectionAdapterNotImplementedRuntimeException();
+            }
+            SectionAdapter sectionAdapter = (SectionAdapter) newAdapter;
+            //noinspection unchecked
+            mSections = SectionData.processSectionGraph(
+                    newAdapter.getItemCount(), sectionAdapter.getSections());
         }
-        SectionAdapter sectionAdapter = (SectionAdapter) newAdapter;
-        //noinspection unchecked
-        mSections = SectionData.processSectionGraph(
-                newAdapter.getItemCount(), sectionAdapter.getSections());
     }
 
     @Override


### PR DESCRIPTION
It is a common practice to set a view's adapter to be null onDestroy in
an effort to clean up resources.